### PR TITLE
Update CMakeLists.txt for new peripheral detection logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1 +1,8 @@
-idf_component_register(SRCS "neopixel.c" INCLUDE_DIRS "." REQUIRES "driver")
+set(priv_requires)
+# Starting from esp-idf v5.3, the peripheral drivers are in separate components
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.3")
+    list(APPEND priv_requires "esp_driver_i2s")
+else()
+    list(APPEND priv_requires "driver")
+endif()
+idf_component_register(SRCS "neopixel.c" INCLUDE_DIRS "include" PRIV_REQUIRES ${priv_requires})


### PR DESCRIPTION
ESP-IDF 6.x (and prior) changed the way it resolves its components.
This results in 2 file not found errors, where the files are still present but blanked out by the resolver. /managed_components/zorxx__neopixel/neopixel.c:13:10: fatal error: driver/i2s_std.h: No such file or directory      
    #include "driver/i2s_std.h"
and #include "driver/i2s_common.h"
This commit changes the CMakeLists.txt for both 'missing' files to be found again in ESP-IDF 6.0.

Tested with 5.5.4 and 6.0. Since other modules mentioned this change to be from <5.3 and resolved the issue with a dynamic switch i also applied the same logic here. See espressif/onewire_bus managed component for that.